### PR TITLE
rocksdb: compilation error on i386

### DIFF
--- a/util/thread_status_impl.cc
+++ b/util/thread_status_impl.cc
@@ -100,7 +100,7 @@ std::map<std::string, uint64_t>
       property_map.insert(
           {"BaseInputLevel", op_properties[i] >> 32});
       property_map.insert(
-          {"OutputLevel", op_properties[i] % (1LU << 32)});
+          {"OutputLevel", op_properties[i] % (1ULL << 32)});
     } else if (op_type == OP_COMPACTION &&
                i == COMPACTION_PROP_FLAGS) {
       property_map.insert(


### PR DESCRIPTION
unsigned long is 32bit on i386, so 1UL<<32 evaluate to 0. and this
is not intended.

Signed-off-by: Kefu Chai <kchai@redhat.com>