### PR TITLE
Fix Ceph build broken in AArm64 architecture

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,8 @@
 # Unreleased
 ### Public API Change
 * Deprecate BlockBaseTableOptions.hash_index_allow_collision=false
+* options.memtable_prefix_bloom_bits changes to options.memtable_prefix_bloom_bits_ratio and deprecate options.memtable_prefix_bloom_probes
+* enum type #movebot Rocksdb Users Group and PerfLevel changes from char to unsigned char. Value of all PerfLevel shift by one.
 
 
 # Rocksdb Change Log

--- a/include/rocksdb/listener.h
+++ b/include/rocksdb/listener.h
@@ -20,7 +20,7 @@ typedef std::unordered_map<std::string, std::shared_ptr<const TableProperties>>
 class DB;
 class Status;
 struct CompactionJobStats;
-enum CompressionType : char;
+enum CompressionType : unsigned char;
 
 enum class TableFileCreationReason {
   kFlush,

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -52,7 +52,7 @@ class WalFilter;
 // sequence of key,value pairs.  Each block may be compressed before
 // being stored in a file.  The following enum describes which
 // compression method (if any) is used to compress a block.
-enum CompressionType : char {
+enum CompressionType : unsigned char {
   // NOTE: do not change the values of existing entries, as these are
   // part of the persistent format on disk.
   kNoCompression = 0x0,
@@ -66,7 +66,7 @@ enum CompressionType : char {
   kZSTDNotFinalCompression = 0x40,
 
   // kDisableCompressionOption is used to disable some compression options.
-  kDisableCompressionOption = -1,
+  kDisableCompressionOption = 0xff,
 };
 
 enum CompactionStyle : char {

--- a/include/rocksdb/perf_level.h
+++ b/include/rocksdb/perf_level.h
@@ -13,14 +13,14 @@ namespace rocksdb {
 
 // How much perf stats to collect. Affects perf_context and iostats_context.
 
-enum PerfLevel : char {
-  kUninitialized = -1,            // unknown setting
-  kDisable = 0,                   // disable perf stats
-  kEnableCount = 1,               // enable only count stats
-  kEnableTimeExceptForMutex = 2,  // Other than count stats, also enable time
+enum PerfLevel : unsigned char {
+  kUninitialized = 0,             // unknown setting
+  kDisable = 1,                   // disable perf stats
+  kEnableCount = 2,               // enable only count stats
+  kEnableTimeExceptForMutex = 3,  // Other than count stats, also enable time
                                   // stats except for mutexes
-  kEnableTime = 3,                // enable count and time stats
-  kOutOfBounds = 4                // N.B. Must always be the last value!
+  kEnableTime = 4,                // enable count and time stats
+  kOutOfBounds = 5                // N.B. Must always be the last value!
 };
 
 // set the perf stats level for current thread

--- a/include/rocksdb/utilities/leveldb_options.h
+++ b/include/rocksdb/utilities/leveldb_options.h
@@ -21,7 +21,7 @@ class Logger;
 struct Options;
 class Snapshot;
 
-enum CompressionType : char;
+enum CompressionType : unsigned char;
 
 // Options to control the behavior of a database (passed to
 // DB::Open). A LevelDBOptions object can be initialized as though

--- a/util/options_builder.cc
+++ b/util/options_builder.cc
@@ -4,6 +4,7 @@
 //  of patent rights can be found in the PATENTS file in the same directory.
 
 #include <math.h>
+#include <cmath>
 #include <algorithm>
 #include "rocksdb/options.h"
 


### PR DESCRIPTION
In ARM the "char" type is treated as "unsigned char", the value
range is from 0 to 255. In the two files options.h and
perf_level.h, the value of the enum type is assigned to "-1".
It is out of the scope. Ceph build will be broken because of the 
issue.
The issue has been fix in facebook/master, rebase the commit
(facebook/rocksdb@9142f29) to ceph/rocksdb.
Also rebase the commit (facebook/rocksdb@2ea2d92) to 
ceph/rocksdb for GCC5.4 compitalbe.