### PR TITLE
build: Improve -momit-leaf-frame-pointer usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,8 @@ endif
 # compile with -O2 if debug level is not 2
 ifneq ($(DEBUG_LEVEL), 2)
 OPT += -O2 -fno-omit-frame-pointer
-ifneq ($(MACHINE),ppc64) # ppc64 doesn't support -momit-leaf-frame-pointer
+# Skip for archs that don't support -momit-leaf-frame-pointer
+ifeq (,$(shell $(CXX) -fsyntax-only -momit-leaf-frame-pointer -xc /dev/null 2>&1))
 OPT += -momit-leaf-frame-pointer
 endif
 endif


### PR DESCRIPTION
-momit-leaf-frame-pointer is only supported on certain archs.
Detect this automatically based on which flags the compiler
understands.

(cherry picked from commit 7ca731b12ce69596d7b9fec4a72d44ca8a3913c3)

Conflicts:
	Makefile (trivial resolution)