### PR TITLE
util/file_read_write: For use_os_buffer, never use buffer of WritableFileWrite

### DIFF
--- a/util/file_reader_writer.cc
+++ b/util/file_reader_writer.cc
@@ -80,9 +80,7 @@ Status WritableFileWriter::Append(const Slice& data) {
   }
 
   // We never write directly to disk with unbuffered I/O on.
-  // or we simply use it for its original purpose to accumulate many small
-  // chunks
-  if (!use_os_buffer_ || (buf_.Capacity() >= left)) {
+  if (!use_os_buffer_ ) {
     while (left > 0) {
       size_t appended = buf_.Append(src, left);
       left -= appended;


### PR DESCRIPTION
Now BlueFS::FileWriter use bufferlist::page_aligned_appender. It copy data of Append API to their buffer.
In rocksdb::WritableFileWriter, it also has the same function buffer.  In fact we can remove this buffer, it can directly copy data to buffer of BlueFS::FileWriter.