### PR TITLE
CMakeLists.txt: FreeBSD does not have JEmalloc includes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,6 @@ else()
   endif()
   if(CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
     # FreeBSD has jemaloc as default malloc
-    add_definitions(-DROCKSDB_JEMALLOC)
     set(WITH_JEMALLOC ON)
   endif()
   option(WITH_SNAPPY "build with SNAPPY" OFF)


### PR DESCRIPTION
- JEmalloc is native malloc for FreeBSD
   But it does not have all the include files of jemalloc

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>