### PR TITLE
env/io_posix.cc: fix for GCC7

### DIFF
--- a/env/io_posix.cc
+++ b/env/io_posix.cc
@@ -22,6 +22,8 @@
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#undef major
+#undef minor
 #ifdef OS_LINUX
 #include <sys/statfs.h>
 #include <sys/syscall.h>


### PR DESCRIPTION
GCC7 build fails with 3 errors, all similar to this one:

/home/abuild/rpmbuild/BUILD/ceph-12.0.2+git.1493119152.181baf6/src/rocksdb/env/io_posix.cc:57:13: error: In the GNU C Library, "major" is defined
by <sys/sysmacros.h>. For historical compatibility, it is
currently defined by <sys/types.h> as well, but we plan to
remove this soon. To use "major", include <sys/sysmacros.h>
directly. If you did not intend to use a system-defined macro
"major", you should undefine it after including <sys/types.h>. [-Werror]
   if (major(buf.st_dev) == 0) {
             ^~~~~~~~~~~~~~~~~~~

Signed-off-by: Nathan Cutler <ncutler@suse.com>