### PR TITLE
specify SSE42 'target' attribute for Fast_CRC32()

### DIFF
--- a/util/crc32c.cc
+++ b/util/crc32c.cc
@@ -313,6 +313,15 @@ static inline void Slow_CRC32(uint64_t* l, uint8_t const **p) {
   table0_[c >> 24];
 }
 
+#if defined(HAVE_SSE42) && defined(__GNUC__)
+#if defined(__clang__)
+#if __has_cpp_attribute(gnu::target)
+__attribute__ ((target ("sse4.2")))
+#endif
+#else  // gcc supports this since 4.4
+__attribute__ ((target ("sse4.2")))
+#endif
+#endif
 static inline void Fast_CRC32(uint64_t* l, uint8_t const **p) {
 #ifndef HAVE_SSE42
   Slow_CRC32(l, p);

--- a/util/crc32c.cc
+++ b/util/crc32c.cc
@@ -385,8 +385,7 @@ static bool isSSE42() {
   return false;
 #elif defined(__GNUC__) && defined(__x86_64__) && !defined(IOS_CROSS_COMPILE)
   uint32_t c_;
-  uint32_t d_;
-  __asm__("cpuid" : "=c"(c_), "=d"(d_) : "a"(1) : "ebx");
+  __asm__("cpuid" : "=c"(c_) : "a"(1) : "ebx", "edx");
   return c_ & (1U << 20);  // copied from CpuId.h in Folly.
 #elif defined(_WIN64)
   int info[4];

--- a/util/crc32c.cc
+++ b/util/crc32c.cc
@@ -407,7 +407,7 @@ bool IsFastCrc32Supported() {
   return isSSE42();
 }
 
-Function ChosenExtend = Choose_Extend();
+static Function ChosenExtend = Choose_Extend();
 
 uint32_t Extend(uint32_t crc, const char* buf, size_t size) {
   return ChosenExtend(crc, buf, size);


### PR DESCRIPTION
we cannot pass -msse42 to cc when compiling the tree if we are preparing
portable binary, which could be running on CPU w/o SSE42 instructions
even the GCC on the building host is able to emit SSE42 code. to solve
this problem, crc32 detects the supported instruction at runtime, and
selects the supported CRC32 implementation according to the result of
`cpuid`. but intrinics like "_mm_crc32_u64()" will not be available
unless the "target" machine is appropriately specified in the command
line, like "-msse42", or using the "target" attribute.

we could pass "-msse42" only when compiling crc32c.cc, and allow the
compiler to generate the SSE42 instructions, but we are still at the
risk of executing illegal instructions on machines does not support
SSE42 if the compiler emits code that is not guarded by our runtime
detection.

or, we can use GCC's function multiversioning to do the dispatch at
runtime. in this way, we have finer grained control of the used
"target". and no need to change the makefiles. so we don't need to
duplicate the changes on both makefile and cmake as the previous
approach.

this problem surfaces when preparing a package for GNU/Linux distribution,
and we only applies to optimization for SSE42, so using the feature
only available on GCC/Clang and i386 is not that formidable.

Signed-off-by: Kefu Chai <tchaikov@gmail.com>