### PR TITLE
Allow to make ceph build reproducible

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,17 +65,7 @@ else()
   endif()
 endif()
 
-if(WIN32)
-  execute_process(COMMAND powershell -noprofile -Command "Get-Date -format MM_dd_yyyy" OUTPUT_VARIABLE DATE)
-  execute_process(COMMAND powershell -noprofile -Command "Get-Date -format HH:mm:ss" OUTPUT_VARIABLE TIME)
-  string(REGEX REPLACE "(..)_(..)_..(..).*" "\\1/\\2/\\3" DATE "${DATE}")
-  string(REGEX REPLACE "(..):(.....).*" " \\1:\\2" TIME "${TIME}")
-  set(GIT_DATE_TIME "${DATE} ${TIME}")
-else()
-  execute_process(COMMAND date "+%Y/%m/%d %H:%M:%S" OUTPUT_VARIABLE DATETIME)
-  string(REGEX REPLACE "\n" "" DATETIME ${DATETIME})
-  set(GIT_DATE_TIME "${DATETIME}")
-endif()
+string(TIMESTAMP ${GIT_DATE_TIME} "%Y/%m/%d %H:%M:%S" UTC)
 
 find_package(Git)
 

--- a/Makefile
+++ b/Makefile
@@ -286,7 +286,7 @@ ifdef FORCE_GIT_SHA
 else
 	git_sha := $(shell git rev-parse HEAD 2>/dev/null)
 endif
-gen_build_version = sed -e s/@@GIT_SHA@@/$(git_sha)/ -e s/@@GIT_DATE_TIME@@/$(date)/ util/build_version.cc.in
+gen_build_version = sed -e s/@@GIT_SHA@@/$(git_sha)/ -e s/@@GIT_DATE_TIME@@/$(date -u -d@$${SOURCE_DATE_EPOCH:-$$(date +%s)})/ util/build_version.cc.in
 
 # Record the version of the source that we are compiling.
 # We keep a record of the git revision in this file.  It is then built


### PR DESCRIPTION
Without the 2nd commit, building the ceph package on openSUSE Linux
always differed:
http://rb.zq1.de/compare.factory-20170711/ceph-compare.out

It requires cmake-2.8.12+ from 2012 or so.