### PR TITLE
env: Structurally dead code env_posix.cc

### DIFF
--- a/env/env_posix.cc
+++ b/env/env_posix.cc
@@ -427,8 +427,6 @@ class PosixEnv : public Env {
       result->reset(new PosixWritableFile(fname, fd, no_mmap_writes_options));
     }
     return s;
-
-    return s;
   }
 
   virtual Status NewRandomRWFile(const std::string& fname,


### PR DESCRIPTION
Fixes the coverity issue:

** 1400664 Structurally dead code
>CID 1400664 (#1 of 1): Structurally dead code (UNREACHABLE)
>unreachable: This code cannot be reached: return rocksdb::Status(s);

Signed-off-by: Amit Kumar <amitkuma@redhat.com>