### PR TITLE
table: Initialization of uninitialized fields

### DIFF
--- a/table/iterator.cc
+++ b/table/iterator.cc
@@ -17,6 +17,8 @@ namespace rocksdb {
 Cleanable::Cleanable() {
   cleanup_.function = nullptr;
   cleanup_.next = nullptr;
+  cleanup_.arg2 = nullptr;
+  cleanup_.arg2 = nullptr;
 }
 
 Cleanable::~Cleanable() { DoCleanup(); }


### PR DESCRIPTION
Fixes the coverity issue:

** 1351695 Uninitialized pointer field

>2. uninit_member: Non-static class member field cleanup_.arg1 is not
initialized in this constructor nor in any functions that it calls.
>CID 1351695 (#1 of 1): Uninitialized pointer field (UNINIT_CTOR)
>4. uninit_member: Non-static class member field cleanup_.arg2 is not
initialized in this constructor nor in any functions that it calls.

Signed-off-by: Amit Kumar <amitkuma@redhat.com>