### PR TITLE
db: Initializing members of class CompactedDBImpl

### DIFF
--- a/db/compacted_db_impl.h
+++ b/db/compacted_db_impl.h
@@ -89,9 +89,9 @@ class CompactedDBImpl : public DBImpl {
   inline size_t FindFile(const Slice& key);
   Status Init(const Options& options);
 
-  ColumnFamilyData* cfd_;
-  Version* version_;
-  const Comparator* user_comparator_;
+  ColumnFamilyData* cfd_ = nullptr;
+  Version* version_ = nullptr;
+  const Comparator* user_comparator_ = nullptr;
   LevelFilesBrief files_;
 
   // No copying allowed


### PR DESCRIPTION
** Fixes the coverity issue:

1396120 Uninitialized pointer field
>2. uninit_member: Non-static class member cfd_ is not initialized in
this constructor nor in any functions that it calls.
>4. uninit_member: Non-static class member version_ is not initialized
in this constructor nor in any functions that it calls.

CID 1396120 (#1 of 1): Uninitialized pointer field (UNINIT_CTOR)
>6. uninit_member: Non-static class member user_comparator_ is not
initialized in this constructor nor in any functions that it calls.

Signed-off-by: Amit Kumar <amitkuma@redhat.com>