### PR TITLE
util: Initialization of member of class ConcurrentArena

### DIFF
--- a/util/concurrent_arena.h
+++ b/util/concurrent_arena.h
@@ -88,7 +88,7 @@ class ConcurrentArena : public Allocator {
   struct Shard {
     char padding[40] ROCKSDB_FIELD_UNUSED;
     mutable SpinMutex mutex;
-    char* free_begin_;
+    char* free_begin_ = nullptr;
     std::atomic<size_t> allocated_and_unused_;
 
     Shard() : allocated_and_unused_(0) {}


### PR DESCRIPTION
Fixes the coverity issue:

** 1396145 Uninitialized pointer field

>CID 1396145 (#1 of 1): Uninitialized pointer field (UNINIT_CTOR)
>2. uninit_member: Non-static class member free_begin_ is not initialized
in this constructor nor in any functions that it calls.

Signed-off-by: Amit Kumar <amitkuma@redhat.com>