### PR TITLE
db: Initialization of members of class FlushJob

### DIFF
--- a/db/flush_job.h
+++ b/db/flush_job.h
@@ -102,8 +102,8 @@ class FlushJob {
   // Variables below are set by PickMemTable():
   FileMetaData meta_;
   autovector<MemTable*> mems_;
-  VersionEdit* edit_;
-  Version* base_;
+  VersionEdit* edit_ = nullptr;
+  Version* base_ = nullptr;
   bool pick_memtable_called;
 };
 


### PR DESCRIPTION
Fixes the coverity issue:

** 1396152 Uninitialized pointer field
>2. uninit_member: Non-static class member edit_ is not initialized
in this constructor nor in any functions that it calls.
>CID 1396152 (#1 of 1): Uninitialized pointer field (UNINIT_CTOR)
>4. uninit_member: Non-static class member base_ is not initialized
in this constructor nor in any functions that it calls.

Signed-off-by: Amit Kumar <amitkuma@redhat.com>