### PR TITLE
util: Initialization of members of struct ThreadData

### DIFF
--- a/util/thread_local.cc
+++ b/util/thread_local.cc
@@ -40,8 +40,8 @@ class StaticMeta;
 struct ThreadData {
   explicit ThreadData(ThreadLocalPtr::StaticMeta* _inst) : entries(), inst(_inst) {}
   std::vector<Entry> entries;
-  ThreadData* next;
-  ThreadData* prev;
+  ThreadData* next = nullptr;
+  ThreadData* prev = nullptr;
   ThreadLocalPtr::StaticMeta* inst;
 };
 


### PR DESCRIPTION
Fixes the coverity issues:

** 1400668 Uninitialized pointer field
>2. uninit_member: Non-static class member next is not initialized
in this constructor nor in any functions that it calls.
>CID 1400668 (#1 of 1): Uninitialized pointer field (UNINIT_CTOR)
>4. uninit_member: Non-static class member prev is not initialized
in this constructor nor in any functions that it calls.

Signed-off-by: Amit Kumar <amitkuma@redhat.com>