### PR TITLE
luminous: Fix the selection of the fast CRC32 path in Ceph Luminous.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,6 +156,24 @@ else()
   endif()
 endif()
 
+include(CheckCXXSourceCompiles)
+if(NOT MSVC)
+  set(CMAKE_REQUIRED_FLAGS "-msse4.2")
+endif()
+CHECK_CXX_SOURCE_COMPILES("
+#include <cstdint>
+#include <nmmintrin.h>
+int main() {
+  volatile uint32_t x = _mm_crc32_u32(0, 0);
+}
+" HAVE_SSE42)
+unset(CMAKE_REQUIRED_FLAGS)
+if(HAVE_SSE42 AND NOT WITH_SSE42)
+set_source_files_properties(
+  util/crc32c.cc
+  PROPERTIES COMPILE_FLAGS "-msse4.2")
+endif()
+
 option(FAIL_ON_WARNINGS "Treat compile warnings as errors" ON)
 if(FAIL_ON_WARNINGS)
   if(MSVC)

--- a/db/compaction_picker.cc
+++ b/db/compaction_picker.cc
@@ -1251,6 +1251,8 @@ uint32_t LevelCompactionBuilder::GetPathId(
   uint64_t level_size;
   int cur_level = 0;
 
+  // max_bytes_for_level_base denotes L1 size.
+  // We estimate L0 size to be the same as L1.
   level_size = mutable_cf_options.max_bytes_for_level_base;
 
   // Last path is the fallback
@@ -1261,8 +1263,10 @@ uint32_t LevelCompactionBuilder::GetPathId(
         return p;
       } else {
         current_path_size -= level_size;
-        level_size = static_cast<uint64_t>(
-            level_size * mutable_cf_options.max_bytes_for_level_multiplier);
+        if (cur_level > 0) {
+          level_size = static_cast<uint64_t>(
+              level_size * mutable_cf_options.max_bytes_for_level_multiplier);
+        }
         cur_level++;
         continue;
       }

--- a/util/crc32c.cc
+++ b/util/crc32c.cc
@@ -327,15 +327,6 @@ static inline void Slow_CRC32(uint64_t* l, uint8_t const **p) {
   table0_[c >> 24];
 }
 
-#if defined(HAVE_SSE42) && defined(__GNUC__)
-#if defined(__clang__)
-#if __has_cpp_attribute(gnu::target)
-__attribute__ ((target ("sse4.2")))
-#endif
-#else  // gcc supports this since 4.4
-__attribute__ ((target ("sse4.2")))
-#endif
-#endif
 static inline void Fast_CRC32(uint64_t* l, uint8_t const **p) {
 #ifdef __SSE4_2__
 #ifdef __LP64__


### PR DESCRIPTION
This ugly patch selectively adds the `-msse4.2` for compiling `util/crc32c.cc` file when a building machine's toolchain had successfully compiled a simple test program. The CXXFLAGS are enriched even when `WITH_SSE42` is not set as, in Ceph, there is no possibility to use the global switch because of lack of proper run-time SSE4.2 check in other places IIUC.
    
Although the problem is fixed in `master` of RocksDB, the fix cannot be backported because the CRC32-related stuff diverged too much (`HAVE_POWER8`, `HAVE_PCLMUL`, `NO_THREEWAY_CRC32C`).
    
The patch strictly targets Ceph Luminous branch.
    
Fixes: http://tracker.ceph.com/issues/22534
Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>

-----

The PR attaches the https://github.com/ceph/rocksdb/commit/62782e7357ff569d836b0ad91e5776fc1d6137e5 as it's being used by v12.2.4.