### PR TITLE
port_posix: use posix_memalign() for aligned_alloc

### DIFF
--- a/port/port_posix.cc
+++ b/port/port_posix.cc
@@ -188,8 +188,6 @@ int GetMaxOpenFiles() {
 void *cacheline_aligned_alloc(size_t size) {
 #if __GNUC__ < 5 && defined(__SANITIZE_ADDRESS__)
   return malloc(size);
-#elif defined(_ISOC11_SOURCE)
-  return aligned_alloc(CACHE_LINE_SIZE, size);
 #elif ( _POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600 || defined(__APPLE__))
   void *m;
   errno = posix_memalign(&m, CACHE_LINE_SIZE, size);


### PR DESCRIPTION
to workaround issue of http://tracker.ceph.com/issues/21422 .
and by using C++17, we can use this new "new" operator. and to be
consistent with the C++17 consumer of this library.

Signed-off-by: Kefu Chai <tchaikov@gmail.com>