### PR TITLE
Fix a compilation error in CircleCI vs2019 CXX20 (#8090)

### DIFF
--- a/third-party/folly/folly/synchronization/DistributedMutex-inl.h
+++ b/third-party/folly/folly/synchronization/DistributedMutex-inl.h
@@ -1374,7 +1374,8 @@ inline std::uintptr_t tryWake(
     // we need release here because of the write to waker_ and also because we
     // are unlocking the mutex, the thread we do the handoff to here should
     // see the modified data
-    new (&waiter->metadata_) Metadata(waker, bit_cast<uintptr_t>(sleepers));
+    new (&waiter->metadata_)
+        Metadata(waker, folly::bit_cast<std::uintptr_t>(sleepers));
     waiter->futex_.store(kWake, std::memory_order_release);
     return 0;
   }


### PR DESCRIPTION
We should be able to compile rocksdb with c++20 on Ubuntu to avoid `free(): invalid pointer` with librados tests.
The compilation (with c++20) causes the following error: 
```
party/folly/folly/synchronization/DistributedMutex.cpp:12:16:   required from here
2022-09-22T08:15:32.145 INFO:tasks.workunit.client.0.smithi157.stderr:/home/ubuntu/cephtest/mnt.0/client.0/tmp/rocksdb/third-party/folly/folly/synchronization/DistributedMutex-inl.h:1377:65: error: call of overloaded 'bit_cast<uintptr_t>(folly::detail::distributed_mutex::Waiter<std::atomic>*&)' is ambiguous
``` 
https://pulpito.ceph.com/matan-2022-09-22_07:51:28-rados:singleton-main-distro-default-smithi/
which was fixed here: https://github.com/facebook/rocksdb/pull/8090

Fixes: https://tracker.ceph.com/issues/57632

(cherry picked from commit 2a12b80769448ad44a69252f1990dd20068defd8)

Signed-off-by: Matan Breizman <mbreizma@redhat.com>