### PR TITLE
include <cstdint> wherever missing

### DIFF
--- a/db/blob/blob_file_meta.h
+++ b/db/blob/blob_file_meta.h
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <cassert>
 #include <iosfwd>
 #include <memory>

--- a/include/rocksdb/trace_record.h
+++ b/include/rocksdb/trace_record.h
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <vector>


### PR DESCRIPTION
Fixes errors like this that are seen while building Ceph repo's main branch on Fedora 42 -

```
repos/ceph/cephfs-host-errno/src/rocksdb/include/rocksdb/trace_record.h:63:11: error: ‘uint64_t’ does not name a type
   63 |   virtual uint64_t GetTimestamp() const;

```