### PR TITLE
include <cstdint> wherever missing

### DIFF
--- a/include/rocksdb/trace_record.h
+++ b/include/rocksdb/trace_record.h
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <vector>


### PR DESCRIPTION
Fixes errors like this that are seen while building Ceph repo's main
branch on Fedora 42, 43 and 44 -

```
repos/ceph/src/rocksdb/include/rocksdb/trace_record.h:55:32: error: expected ‘)’ before ‘timestamp’
   55 |   explicit TraceRecord(uint64_t timestamp);
   ```